### PR TITLE
Fix Camt053V3 generator element stack mismatch

### DIFF
--- a/src/main/java/com/serrala/sepa/util/Camt053V3Generator.java
+++ b/src/main/java/com/serrala/sepa/util/Camt053V3Generator.java
@@ -158,7 +158,6 @@ public class Camt053V3Generator {
             w.writeCharacters("GDSV");
             w.writeEndElement();
             w.writeEndElement(); // Fmly
-            w.writeEndElement(); // Fmly
             w.writeEndElement(); // Domn
             w.writeEndElement(); // BkTxCd
 


### PR DESCRIPTION
## Summary
- remove an extraneous `writeEndElement` call in `Camt053V3Generator`

The extra closing tag caused `XMLStreamWriterImpl` to throw an `ArrayIndexOutOfBoundsException` when generating CAMT053 v3 statements.

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b3b91b848321b1cf4d6ddee3c3ae