### PR TITLE
Add converter utility for pain.001 to CAMT053

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ mvn clean install
 ### Usage
 - Add this library as a dependency in your project
 - Use the provided parser class to parse pain.001 files
+- Generate CAMT053 v3 and v8 statements using `SepaCtToCamt53Converter`
+
+```java
+File painFile = new File("payment.xml");
+SepaCtToCamt53Converter.ConversionResult result =
+        SepaCtToCamt53Converter.convert(painFile);
+String camt53v3 = result.getCamt53V3Xml();
+String camt53v8 = result.getCamt53V8Xml();
+```
 
 ## Project Structure
 - `src/main/java/com/serrala/sepa/model` - Data models for extracted information

--- a/src/main/java/com/serrala/sepa/util/SepaCtToCamt53Converter.java
+++ b/src/main/java/com/serrala/sepa/util/SepaCtToCamt53Converter.java
@@ -1,0 +1,57 @@
+package com.serrala.sepa.util;
+
+import java.io.File;
+
+import com.serrala.sepa.model.SepaStatement;
+import com.serrala.sepa.parser.SepaCtPain001StaxParser;
+
+/**
+ * Utility class that converts SEPA Credit Transfer (pain.001) files into
+ * CAMT053 statement XML strings. Missing mandatory CAMT fields are
+ * automatically populated with placeholder values via
+ * {@link SepaStatementUtils#ensureMandatoryFields(SepaStatement)}.
+ */
+public final class SepaCtToCamt53Converter {
+
+    private SepaCtToCamt53Converter() {
+        // utility class
+    }
+
+    /**
+     * Parses the provided pain.001 file and generates CAMT053 statement strings
+     * for versions 3 and 8.
+     *
+     * @param pain001File the SEPA Credit Transfer file to convert
+     * @return result object containing the CAMT053 v3 and v8 XML strings
+     * @throws Exception if parsing or generation fails
+     */
+    public static ConversionResult convert(File pain001File) throws Exception {
+        SepaCtPain001StaxParser parser = new SepaCtPain001StaxParser();
+        SepaStatement statement = parser.parse(pain001File);
+        SepaStatementUtils.ensureMandatoryFields(statement);
+        String camt53v3 = Camt053V3Generator.generate(statement);
+        String camt53v8 = Camt053V8Generator.generate(statement);
+        return new ConversionResult(camt53v3, camt53v8);
+    }
+
+    /**
+     * Holder for generated CAMT053 statement XML.
+     */
+    public static class ConversionResult {
+        private final String camt53V3Xml;
+        private final String camt53V8Xml;
+
+        public ConversionResult(String camt53V3Xml, String camt53V8Xml) {
+            this.camt53V3Xml = camt53V3Xml;
+            this.camt53V8Xml = camt53V8Xml;
+        }
+
+        public String getCamt53V3Xml() {
+            return camt53V3Xml;
+        }
+
+        public String getCamt53V8Xml() {
+            return camt53V8Xml;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SepaCtToCamt53Converter` to convert pain.001 into CAMT053 statements
- document converter usage in README

## Testing
- `mvn -version` *(fails: command not found)*
- `javac $(find src/main/java -name "*.java")` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862b7aed1308321b5fc074ff1ef6663