### PR TITLE
Add converter unit test

### DIFF
--- a/src/test/java/com/serrala/sepa/util/SepaCtToCamt53ConverterTest.java
+++ b/src/test/java/com/serrala/sepa/util/SepaCtToCamt53ConverterTest.java
@@ -1,0 +1,24 @@
+package com.serrala.sepa.util;
+
+import java.io.File;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link SepaCtToCamt53Converter}.
+ */
+public class SepaCtToCamt53ConverterTest extends TestCase {
+
+    /**
+     * Converts a sample pain.001 file and verifies CAMT053 outputs are generated.
+     */
+    public void testConvertPain001() throws Exception {
+        File xml = new File(getClass().getClassLoader().getResource("Bayer_HealthTech.xml").toURI());
+        SepaCtToCamt53Converter.ConversionResult result = SepaCtToCamt53Converter.convert(xml);
+        assertNotNull(result);
+        assertNotNull(result.getCamt53V3Xml());
+        assertNotNull(result.getCamt53V8Xml());
+        assertTrue(result.getCamt53V3Xml().contains("urn:iso:std:iso:20022:tech:xsd:camt.053.001.03"));
+        assertTrue(result.getCamt53V8Xml().contains("urn:iso:std:iso:20022:tech:xsd:camt.053.001.08"));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit test for `SepaCtToCamt53Converter`

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862bb1b8e348321afbc9d6575fc80e3