### PR TITLE
Support booking/value dates

### DIFF
--- a/src/main/java/com/serrala/sepa/parser/SepaCtPain001Parser.java
+++ b/src/main/java/com/serrala/sepa/parser/SepaCtPain001Parser.java
@@ -77,10 +77,25 @@ public class SepaCtPain001Parser implements StatementParser {
                     Element strd = getChildElementNS(rmtInf, "Strd");
                     if (strd != null) {
                         ustrd = getElementTextNS(strd, "Ustrd");
+                        if (ustrd == null) {
+                            ustrd = strd.getTextContent();
+                        }
                     }
                 }
             }
             tx.setRemittanceInfo(ustrd);
+            // Booking/Value dates from ReqdExctnDt of parent PmtInf
+            Node parentNode = txElem.getParentNode();
+            while (parentNode != null && parentNode.getNodeType() == Node.ELEMENT_NODE) {
+                Element parentElem = (Element) parentNode;
+                if ("PmtInf".equals(parentElem.getLocalName())) {
+                    String exctnDt = getElementTextNS(parentElem, "ReqdExctnDt");
+                    tx.setBookingDate(exctnDt);
+                    tx.setValueDate(exctnDt);
+                    break;
+                }
+                parentNode = parentNode.getParentNode();
+            }
             tx.setAmount(getElementTextNS(txElem, "InstdAmt"));
             tx.setCurrency(getElementAttributeNS(txElem, "InstdAmt", "Ccy"));
             tx.setEndToEndId(getElementTextNS(txElem, "EndToEndId"));

--- a/src/main/java/com/serrala/sepa/util/Camt053V3Generator.java
+++ b/src/main/java/com/serrala/sepa/util/Camt053V3Generator.java
@@ -142,6 +142,21 @@ public class Camt053V3Generator {
             w.writeCharacters("BOOK");
             w.writeEndElement(); // Sts
 
+            if (tx.getBookingDate() != null) {
+                w.writeStartElement("BookgDt");
+                w.writeStartElement("Dt");
+                w.writeCharacters(tx.getBookingDate());
+                w.writeEndElement();
+                w.writeEndElement();
+            }
+            if (tx.getValueDate() != null) {
+                w.writeStartElement("ValDt");
+                w.writeStartElement("Dt");
+                w.writeCharacters(tx.getValueDate());
+                w.writeEndElement();
+                w.writeEndElement();
+            }
+
             // Minimal bank transaction code
             w.writeStartElement("BkTxCd");
             w.writeStartElement("Domn");

--- a/src/main/java/com/serrala/sepa/util/Camt053V8Generator.java
+++ b/src/main/java/com/serrala/sepa/util/Camt053V8Generator.java
@@ -142,6 +142,21 @@ public class Camt053V8Generator {
             w.writeCharacters("BOOK");
             w.writeEndElement(); // Sts
 
+            if (tx.getBookingDate() != null) {
+                w.writeStartElement("BookgDt");
+                w.writeStartElement("Dt");
+                w.writeCharacters(tx.getBookingDate());
+                w.writeEndElement();
+                w.writeEndElement();
+            }
+            if (tx.getValueDate() != null) {
+                w.writeStartElement("ValDt");
+                w.writeStartElement("Dt");
+                w.writeCharacters(tx.getValueDate());
+                w.writeEndElement();
+                w.writeEndElement();
+            }
+
             // Minimal bank transaction code
             w.writeStartElement("BkTxCd");
             w.writeStartElement("Domn");

--- a/src/main/java/com/serrala/sepa/util/SepaStatementUtils.java
+++ b/src/main/java/com/serrala/sepa/util/SepaStatementUtils.java
@@ -55,6 +55,12 @@ public class SepaStatementUtils {
                 if (isBlank(tx.getEndToEndId())) {
                     tx.setEndToEndId("ID" + ((int) (Math.random() * 1_000_000)));
                 }
+                if (isBlank(tx.getBookingDate())) {
+                    tx.setBookingDate(new SimpleDateFormat("yyyy-MM-dd").format(new Date()));
+                }
+                if (isBlank(tx.getValueDate())) {
+                    tx.setValueDate(tx.getBookingDate());
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- parse `ReqdExctnDt` and assign to booking/value dates when converting pain.001
- carry booking and value dates through CAMT053 generation
- capture structured remittance text if `Ustrd` is missing
- ensure booking/value dates have defaults when not provided

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862bcd601ec8321b39bc2c2b4b3f4f6