### PR TITLE
Fix CAMT053 Sts element

### DIFF
--- a/src/main/java/com/serrala/sepa/util/Camt053V3Generator.java
+++ b/src/main/java/com/serrala/sepa/util/Camt053V3Generator.java
@@ -139,7 +139,9 @@ public class Camt053V3Generator {
             w.writeEndElement();
 
             w.writeStartElement("Sts");
+            w.writeStartElement("Cd");
             w.writeCharacters("BOOK");
+            w.writeEndElement();
             w.writeEndElement(); // Sts
 
             if (tx.getBookingDate() != null) {

--- a/src/main/java/com/serrala/sepa/util/Camt053V8Generator.java
+++ b/src/main/java/com/serrala/sepa/util/Camt053V8Generator.java
@@ -139,7 +139,9 @@ public class Camt053V8Generator {
             w.writeEndElement();
 
             w.writeStartElement("Sts");
+            w.writeStartElement("Cd");
             w.writeCharacters("BOOK");
+            w.writeEndElement();
             w.writeEndElement(); // Sts
 
             if (tx.getBookingDate() != null) {


### PR DESCRIPTION
## Summary
- ensure `<Sts>` includes `<Cd>` in CAMT053 v3/v8 generators

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637488239083218ce2dc51e607a08d